### PR TITLE
Fix: use GitHub hosted runner for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,14 +5,14 @@ on:
   #  branches: [ "master" ]
   #pull_request:
   #  # The branches below must be a subset of the branches above
-  #  branches: [ "master" ]
+  #  branches: [ "v1" ]
   schedule:
     - cron: '5 20 * * 0,2,4'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: infosec-codeql
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,8 @@
 name: "CodeQL Scan"
 
 on:
-  #push:
-  #  branches: [ "master" ]
-  #pull_request:
-  #  # The branches below must be a subset of the branches above
-  #  branches: [ "v1" ]
-  schedule:
-    - cron: '5 20 * * 0,2,4'
+  pull_request:
+   branches: [ "v1" ]
 
 jobs:
   analyze:


### PR DESCRIPTION
Prior to being open-sourced this repository was using a self-hosted GitHub runner. The self-hosted runner is no longer available in the `fox-tech` GitHub organization.

This PR updates the workflow to use a GitHub hosted runner instead. The workflow is also updated to run on pull requests to the `v1` branch rather than on a cron in order to only run code scanning when necessary and cut down on GitHub Action minute usage.